### PR TITLE
Added ipython_setup.sh, a tool for creating temporary ipython profiles.

### DIFF
--- a/ipython_setup.sh
+++ b/ipython_setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Execute:
+# source ipython_setup.sh
+# before launching ipython or jupyter notebooks to automatically create a temporary ipython profile in
+# /tmp/arc-ipython-profiles. This avoids distrupting any existing profiles and reduces the chance of 
+# conflict by using a "known good" profile.
+# Also adds the "tools" subdir to the PYTHONPATH
+
+
+PROFILE_LOC=/tmp/arc-ipython-profiles
+export IPYTHONDIR=$PROFILE_LOC
+
+mkdir -p $PROFILE_LOC
+bash -c 'ipython profile create > /dev/null'
+cp tools/ipython_config.py $PROFILE_LOC/profile_default/ipython_config.py 
+export PYTHONPATH=$PYTHONPATH:$(readlink -f tools)
+
+
+
+


### PR DESCRIPTION
When sourced in a shell this script creates, and sets env vars to use,
an ipython profile in /tmp.

1) "tools" dir is added to PYTHONPATH
2) "tools/ipython_config.py" is used in the created profile.

This avoids using the user ipython profile and automatically enables the
defined magics in ipython_config.py.